### PR TITLE
add dependencies and refactor app so that the API can be tested

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,8 +2,11 @@ package app
 
 import (
 	"fx.prodigy9.co/cmd"
+	"fx.prodigy9.co/config"
+	"fx.prodigy9.co/httpserver"
 	"fx.prodigy9.co/httpserver/controllers"
 	"fx.prodigy9.co/httpserver/middlewares"
+	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
 )
 
@@ -15,6 +18,14 @@ type Interface interface {
 	Commands() []*cobra.Command
 	Middlewares() []middlewares.Interface
 	Controllers() []controllers.Interface
+}
+
+func GetRouter(app Interface) *chi.Mux {
+	cfg := config.Configure()
+	_, mws, ctrs := collect(app)
+	srv := httpserver.New(cfg, mws, ctrs)
+	_ = srv.PrepareRouter()
+	return srv.GetRouter()
 }
 
 func Start(app Interface) error {

--- a/app/builder.go
+++ b/app/builder.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fx.prodigy9.co/httpserver/controllers"
 	"fx.prodigy9.co/httpserver/middlewares"
+	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
 )
 
@@ -10,8 +11,9 @@ type Builder struct {
 	appImpl
 }
 
-func Build() *Builder           { return &Builder{} }
-func (b *Builder) Start() error { return Start(&b.appImpl) }
+func Build() *Builder                  { return &Builder{} }
+func (b *Builder) Start() error        { return Start(&b.appImpl) }
+func (b *Builder) GetRouter() *chi.Mux { return GetRouter(&b.appImpl) }
 
 func (b *Builder) Name(name string) *Builder {
 	b.name = name

--- a/cmd/data/collect_migrations_cmd.go
+++ b/cmd/data/collect_migrations_cmd.go
@@ -17,10 +17,10 @@ import (
 var collectMigrationsCmd = &cobra.Command{
 	Use:   "collect-migrations (outdir)",
 	Short: "Copies all detected migration files in the repository to the specified directory.",
-	RunE:  runCollectMigrationsCmd,
+	RunE:  RunCollectMigrationsCmd,
 }
 
-func runCollectMigrationsCmd(cmd *cobra.Command, args []string) (err error) {
+func RunCollectMigrationsCmd(cmd *cobra.Command, args []string) (err error) {
 	defer errutil.Wrap("collect-migrations", &err)
 
 	var (

--- a/cmd/data/new_migration_cmd.go
+++ b/cmd/data/new_migration_cmd.go
@@ -19,7 +19,7 @@ import (
 
 const upMigrationTemplate = `-- vim: filetype=SQL
 CREATE TABLE dummy (
-	id TEXT PRIMARY KEY,
+	id VARCHAR(26) PRIMARY KEY,
 	created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 `

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -15,6 +15,9 @@ func BuildServeCommand(mws []middlewares.Interface, ctrs []controllers.Interface
 		RunE: func(_ *cobra.Command, args []string) error {
 			cfg := config.Configure()
 			srv := httpserver.New(cfg, mws, ctrs)
+			if err := srv.PrepareRouter(); err != nil {
+				return err
+			}
 			return srv.Start()
 		},
 	}

--- a/deps/deps.go
+++ b/deps/deps.go
@@ -1,0 +1,64 @@
+// Package deps
+// stores providers for dependencies that will be mocked for tests
+package deps
+
+import (
+	"fmt"
+)
+
+type Store struct {
+	deps map[interface{}]interface{}
+}
+
+var defaultStore = &Store{deps: make(map[interface{}]interface{})}
+
+// Set sets a provider, wont set if exists
+func Set(key interface{}, provider func(params ...interface{}) interface{}) {
+	if _, exists := defaultStore.deps[key]; exists {
+		return
+	}
+	defaultStore.deps[key] = provider
+}
+
+// SetDirect sets a provider
+func SetDirect(key interface{}, provider func(params ...interface{}) interface{}) {
+	defaultStore.deps[key] = provider
+}
+
+// GetProvider get existing provider
+func GetProvider(key interface{}) func(params ...interface{}) interface{} {
+	if provider, exists := defaultStore.deps[key]; exists {
+		p, _ := provider.(func(params ...interface{}) interface{})
+		return p
+	}
+	return nil
+}
+
+// Execute executes a provider and returns the typed value
+func Execute[T comparable](key interface{}, providerParams ...interface{}) T {
+	providerVal, exists := defaultStore.deps[key]
+	provider, typed := providerVal.(func(params ...interface{}) interface{})
+	if !exists || !typed {
+		panic(fmt.Sprintf("missing dependency with key: %T", key))
+	}
+	resultVal := provider(providerParams...)
+	result, typed := resultVal.(T)
+	if !typed {
+		panic(fmt.Sprintf("couldn't cast dependency to target type: %T", new(T)))
+	}
+	return result
+}
+
+// Provider wraps a provider to add a parameter with a type for it
+func Provider[T comparable](provider func(p T) interface{}) func(params ...interface{}) interface{} {
+	return func(params ...interface{}) interface{} {
+		if len(params) != 1 {
+			panic("missing parameter")
+		}
+		ctx, ok := params[0].(T)
+		if !ok {
+			panic("wrong type")
+		}
+		return provider(ctx)
+	}
+}


### PR DESCRIPTION
- refactor `Builder`, `app`, `httpserver` to allow access to the router for testing the API
  - migration cmds
    - refactor in  so that they can be called from the tests
    - change PK from TEXT to VARCHAR
 - `deps` package stores providers for dependencies that will be mocked for tests ie. GoogleIDToken validator, external APIs, etc; refer to [rpg](https://github.com/prod9/rabbit-pg-adapter)